### PR TITLE
Move log links into single row

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,32 @@
+{
+  "name": "pressmatic-addon-logs",
+  "version": "1.0.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "commander": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
+      "integrity": "sha1-0SG7roYNmZKj1Re6lvVliOR8Z4E="
+    },
+    "file-size-watcher": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/file-size-watcher/-/file-size-watcher-0.2.1.tgz",
+      "integrity": "sha1-Bnq2Apap/kxtuCJmFgFND3pvyw8="
+    },
+    "file-tail": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/file-tail/-/file-tail-0.3.0.tgz",
+      "integrity": "sha1-WIswov3/EnWumMgxmoiWDwqmUKs=",
+      "requires": {
+        "commander": "2.1.0",
+        "file-size-watcher": "0.2.1"
+      }
+    },
+    "fs-reader": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fs-reader/-/fs-reader-1.0.1.tgz",
+      "integrity": "sha1-jJzaCiS1uxpbx+APh/YmeLoo+3g="
+    }
+  }
+}

--- a/style.css
+++ b/style.css
@@ -30,7 +30,7 @@
     bottom: 0;
     position: absolute;
     width: 100%;
-    height: 47px;
+    height: 43px;
     padding: 10px 15px;
     background: #f6f6f6;
     border-color: #ccc;
@@ -46,7 +46,7 @@
 .logs-container .toolbar-actions {
     margin: 0;
     padding: 0;
-    display: inline-block;
+    display: inline-flex;
 }
 
 .logs-container .btn-group > .btn:only-child {

--- a/style.css
+++ b/style.css
@@ -12,6 +12,10 @@
     width: 100%;
 }
 
+.logs-container .logview h4 {
+    margin-bottom: .5em;
+ }
+ 
 .logs-container .logview-monitor {
     position: relative;
     top: 0;


### PR DESCRIPTION
In Local by Flywheel v2.0.x, the links to the individual logs all stack on each other and overflow the toolbar container. This adjusts the links to use flexbox, and fixes overflow to display the logs correctly to match they way they worked in Pressmatic 1.x.