### PR TITLE
Add support for WP_DEBUG log

### DIFF
--- a/lib/SiteInfoLogs.js
+++ b/lib/SiteInfoLogs.js
@@ -38,6 +38,7 @@ module.exports = function (context) {
 			_this.showPhpError = _this.showPhpError.bind(_this);
 			_this.showPhpFpm = _this.showPhpFpm.bind(_this);
 			_this.showPMLog = _this.showPMLog.bind(_this);
+			_this.showWPDebugLog = _this.showWPDebugLog.bind(_this);
 
 			_this.siteID = this.props.params.siteID;
 			_this.site = this.props.sites[_this.siteID];
@@ -48,6 +49,7 @@ module.exports = function (context) {
 
 			_this.stylesheetPath = path.resolve(__dirname, '../style.css');
 			_this.logPath = path.resolve(this.site.path, 'logs');
+			_this.wpContentPath = path.resolve(this.site.path, 'app/public/wp-content')
 			_this.apacheClass = this.site.webServer === 'apache' ? '' : ' hiddenGroup';
 			_this.nginxClass = this.site.webServer === 'nginx' ? '' : ' hiddenGroup';
 			_this.pmClass = context.process.platform !== 'darwin' ? '' : ' hiddenGroup';
@@ -61,6 +63,8 @@ module.exports = function (context) {
 
 				if(activeView === 'pmLog') {
 					_logFile = path.resolve(context.environment.userHome, 'Library/Logs/Pressmatic.log');
+				} else if (activeView === 'wpDebugLog') {
+					_logFile = path.resolve(this.wpContentPath, 'debug.log');
 				} else {
 					_logFile = path.resolve(this.logPath, file);
 				}
@@ -152,6 +156,13 @@ module.exports = function (context) {
 				this.getLog(false, this.activeView);
 			}
 		}, {
+			key: 'showWPDebugLog',
+			value: function showWPDebugLog() {
+				this.viewTitle = 'WP Debug Log';
+				this.activeView = 'wpDebugLog';
+				this.getLog(false, this.activeView);
+			}
+		}, {
 			key: 'render',
 			value: function render() {
 				return React.createElement(
@@ -213,6 +224,11 @@ module.exports = function (context) {
 								'div',
 								{ style: { display: this.activeView === 'pmLog' ? 'block' : 'none' },
 								className: 'padded-horizontally-more logview-monitor pmLog' }
+							),
+							React.createElement(
+								'div',
+								{ style: { display: this.activeView === 'wpDebugLog' ? 'block' : 'none' },
+								className: 'padded-horizontally-more logview-monitor wpDebugLog' }
 							)
 						),
 						React.createElement(
@@ -307,6 +323,17 @@ module.exports = function (context) {
 											disabled: this.activeView && this.activeView === 'pmLog',
 											onClick: this.showPMLog },
 										'Pressmatic'
+									)
+								),
+								React.createElement(
+									'div',
+									{ className: 'btn-group' },
+									React.createElement(
+										'button',
+										{ className: 'btn btn-primary btn-small',
+											disabled: this.activeView && this.activeView === 'wpDebugLog',
+											onClick: this.showWPDebugLog },
+										'WP Debug'
 									)
 								)
 							)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,32 @@
+{
+  "name": "pressmatic-addon-logs",
+  "version": "1.0.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "commander": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
+      "integrity": "sha1-0SG7roYNmZKj1Re6lvVliOR8Z4E="
+    },
+    "file-size-watcher": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/file-size-watcher/-/file-size-watcher-0.2.1.tgz",
+      "integrity": "sha1-Bnq2Apap/kxtuCJmFgFND3pvyw8="
+    },
+    "file-tail": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/file-tail/-/file-tail-0.3.0.tgz",
+      "integrity": "sha1-WIswov3/EnWumMgxmoiWDwqmUKs=",
+      "requires": {
+        "commander": "2.1.0",
+        "file-size-watcher": "0.2.1"
+      }
+    },
+    "fs-reader": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fs-reader/-/fs-reader-1.0.1.tgz",
+      "integrity": "sha1-jJzaCiS1uxpbx+APh/YmeLoo+3g="
+    }
+  }
+}


### PR DESCRIPTION
This adds an additional link to the logs list to get the `wp-content/debug.log` file and display it.

It includes functions for getting the path to `wp-content` where the log file is stored, extends `getLog()` to look for the debug log outside of the regular `logs` directory, and creates the rendering functions for it.

Implements #3.